### PR TITLE
Improved CLI for Training

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,17 @@ This repository contains a tensorflow implementation of SqueezeDet, a convolutio
   tar -xzvf VGG16.tgz
   ```
 
-- Now we can start training. Training script can be found in `$SQDT_ROOT/scripts/train.sh`, which contains commands to train 4 models: SqueezeDet, SqueezeDet+, VGG16+ConvDet, ResNet50+ConvDet. Un-comment the model you want to train, and then, type:
+- Now we can start training. Training script can be found in `$SQDT_ROOT/scripts/train.sh`, which contains commands to train 4 models: SqueezeDet, SqueezeDet+, VGG16+ConvDet, ResNet50+ConvDet. Un-comment the model you want to train, and then, type the following to train using only the CPU:
 
   ```Shell
   cd $SQDT_ROOT/
-  ./scripts/train.sh
+  ./scripts/train.sh squeezeDet
+  ```
+
+  To train using the GPU, add the `-gpu` flag.
+  
+  ```Shell
+  ./scripts/train.sh squeezeDet -gpu
   ```
 
   Training logs are saved to the directory specified by `--train_dir`. 

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -1,9 +1,39 @@
 #!/bin/bash
 
+export USE_GPU=0
+
+if [ $# -eq 0 ]
+then
+  echo "[ERROR] Missing an argument; please specify the model to use. Use -h or --help for more detailed usage instructions."
+fi
+
+while test $# -gt 0; do
+  case "$1" in
+    -h|--help)
+      echo "Usage: ./scripts/train.sh (squeezeDet|squeezeDet+|vgg16|resnet50) [options]"
+      echo " "
+      echo "options:"
+      echo "-h, --help                show brief help"
+      echo "-gpu                      run with gpu"
+      exit 0
+      ;;
+    -gpu)
+      shift
+      export USE_GPU=1
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
 # =========================================================================== #
 # command for squeezeDet:
 # =========================================================================== #
-python ./src/train.py \
+if [[ "$1" == "squeezeDet" ]]
+then
+  python ./src/train.py \
   --dataset=KITTI \
   --pretrained_model_path=./data/SqueezeNet/squeezenet_v1.1.pkl \
   --data_path=./data/KITTI \
@@ -12,46 +42,56 @@ python ./src/train.py \
   --net=squeezeDet \
   --summary_step=100 \
   --checkpoint_step=500 \
-  --gpu=0
+  --gpu=$USE_GPU
+fi
 
 # =========================================================================== #
 # command for squeezeDet+:
 # =========================================================================== #
-# python ./src/train.py \
-#   --dataset=KITTI \
-#   --pretrained_model_path=./data/SqueezeNet/squeezenet_v1.0_SR_0.750.pkl \
-#   --data_path=./data/KITTI \
-#   --image_set=train \
-#   --train_dir=/tmp/bichen/logs/SqueezeDetPlus/train \
-#   --net=squeezeDet+ \
-#   --summary_step=100 \
-#   --checkpoint_step=500 \
-#   --gpu=0
+if [[ "$1" == "squeezeDet+" ]]
+then
+  python ./src/train.py \
+  --dataset=KITTI \
+  --pretrained_model_path=./data/SqueezeNet/squeezenet_v1.0_SR_0.750.pkl \
+  --data_path=./data/KITTI \
+  --image_set=train \
+  --train_dir=/tmp/bichen/logs/SqueezeDetPlus/train \
+  --net=squeezeDet+ \
+  --summary_step=100 \
+  --checkpoint_step=500 \
+  --gpu=$USE_GPU
+fi
 
 # =========================================================================== #
 # command for vgg16:
 # =========================================================================== #
-# python ./src/train.py \
-#   --dataset=KITTI \
-#   --pretrained_model_path=./data/VGG16/VGG_ILSVRC_16_layers_weights.pkl \
-#   --data_path=./data/KITTI \
-#   --image_set=train \
-#   --train_dir=/tmp/bichen/logs/vgg16/train \
-#   --net=vgg16 \
-#   --summary_step=100 \
-#   --checkpoint_step=500 \
-#   --gpu=0
+if [[ "$1" == "vgg16" ]]
+then
+  python ./src/train.py \
+  --dataset=KITTI \
+  --pretrained_model_path=./data/VGG16/VGG_ILSVRC_16_layers_weights.pkl \
+  --data_path=./data/KITTI \
+  --image_set=train \
+  --train_dir=/tmp/bichen/logs/vgg16/train \
+  --net=vgg16 \
+  --summary_step=100 \
+  --checkpoint_step=500 \
+  --gpu=$USE_GPU
+fi
 
 # =========================================================================== #
 # command for resnet50:
 # =========================================================================== #
-# python ./src/train.py \
-#   --dataset=KITTI \
-#   --pretrained_model_path=./data/ResNet/ResNet-50-weights.pkl \
-#   --data_path=./data/KITTI \
-#   --image_set=train \
-#   --train_dir=/tmp/bichen/logs/resnet/train \
-#   --net=resnet50 \
-#   --summary_step=100 \
-#   --checkpoint_step=500 \
-#   --gpu=0
+if [[ "$1" == "resnet50" ]]
+then
+  python ./src/train.py \
+  --dataset=KITTI \
+  --pretrained_model_path=./data/ResNet/ResNet-50-weights.pkl \
+  --data_path=./data/KITTI \
+  --image_set=train \
+  --train_dir=/tmp/bichen/logs/resnet/train \
+  --net=resnet50 \
+  --summary_step=100 \
+  --checkpoint_step=500 \
+  --gpu=$USE_GPU
+fi


### PR DESCRIPTION
Previously, users needed to comment/uncomment relevant lines of code in `train.sh` to train different models. To make modifications to arguments, users additionally needed to modify train.sh. Now, users simply pass arguments. For example the following trains the `squeezeDet` model on GPU.

```
./scripts/train.sh squeezeDet -gpu
```

For now, this is how to use the script. We can add arguments later, but I felt this was the bare minimum to run CI tests.

```
Usage: ./scripts/train.sh (squeezeDet|squeezeDet+|vgg16|resnet50) [options]

options:
-h, --help                show brief help
-gpu                      run with gpu
```