### PR TITLE
Add script for finding optimal anchor shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,14 @@ The following instructions are written for Linux-based distros.
   ![alt text](https://github.com/BichenWuUCB/squeezeDet/blob/master/README/detection_analysis.png)
   ![alt text](https://github.com/BichenWuUCB/squeezeDet/blob/master/README/graph.png)
   ![alt text](https://github.com/BichenWuUCB/squeezeDet/blob/master/README/det_img.png)
+
+
+## Customizing for your own dataset
+### Computing optimal anchors
+The shapes of the anchors in `src/config/kitti_<model>_config.py` are optimized for the KITTI dataset.
+To customize them for your own dataset, you can use `scripts/kmeans_anchors.py`:
+```Shell
+cd $SQDT_ROOT/
+pip install -r requirements_tools.txt
+python scripts/kmeans_anchors.py
+```

--- a/requirements_utils.txt
+++ b/requirements_utils.txt
@@ -1,0 +1,4 @@
+sklearn
+matplotlib
+tqdm
+futures

--- a/scripts/kmeans_anchors.py
+++ b/scripts/kmeans_anchors.py
@@ -1,0 +1,150 @@
+# Author: Mihai Martalogu (mihai@martalogu.com) 06/16/2017
+"""
+Computes anchor sizes optimized for your dataset
+"""
+import os
+import subprocess
+import itertools
+import argparse
+import inspect
+import multiprocessing
+
+import numpy as np
+import matplotlib.pyplot as plt
+from sklearn.cluster import KMeans
+from tqdm import tqdm
+import concurrent.futures
+
+
+
+def flatten(list_of_lists):
+    return list(itertools.chain.from_iterable(list_of_lists))
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Computes anchor sizes optimized for your dataset',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--dataset-layout', default='kitti', choices=['kitti'],
+                        help='Layout of the dataset')
+    parser.add_argument('-j', '--jobs', default=multiprocessing.cpu_count() * 2,
+                        help='Number of parallel jobs to spawn')
+    
+    script_path = inspect.stack()[0][1]     # https://stackoverflow.com/a/6628348
+    parser.add_argument('--dataset-root',
+                        default=os.path.abspath(os.path.join(os.path.dirname(script_path),
+                                                             '../data/KITTI')),
+                        help='Root directory of the dataset')
+    parser.add_argument('--input-size', default='320x427',
+                        help='Geometry of the image input for the neural net, in the form of a' +
+                             ' <width>x<height> string')
+    parser.add_argument('--k', default=9, type=int,
+                        help='Number of anchors')
+    args = parser.parse_args()
+    input_w, input_h = (int(x) for x in args.input_size.split('x'))
+    metadata = get_dataset_metadata(args.dataset_root, input_w, input_h, args.jobs)
+    print_anchors(args.k, metadata)
+
+
+
+
+def get_dataset_metadata(dataset_root, input_w, input_h, max_jobs):
+    """
+    Load all dataset metadata into memory. You might need to adapt this if your dataset is really huge.
+    """
+    nonlocals = {   # Python 2 doesn't support nonlocal, using a mutable dict() instead
+        'entries_done': 0,
+        'metadata': dict(),
+        'entries_done_pbar': None
+    }
+    with open(os.path.join(dataset_root, 'ImageSets', 'trainval.txt')) as f:
+        dataset_entries = f.read().splitlines()
+    with concurrent.futures.ProcessPoolExecutor(max_workers=max_jobs) as pool:
+
+        for entry in tqdm(dataset_entries, desc='Scheduling jobs'):
+            if nonlocals['entries_done_pbar'] is None:
+                # instantiating here so that it appears after the 'Scheduling jobs' one
+                nonlocals['entries_done_pbar'] = tqdm(total=len(dataset_entries), desc='Retrieving metadata')
+
+            def entry_done(future):
+                """ Record progress """
+                nonlocals['entries_done'] += 1
+                nonlocals['entries_done_pbar'].update(1)
+                fr = future.result()
+                if fr is not None:
+                    nonlocals['metadata'][entry] = fr
+
+            future = pool.submit(get_entry_metadata, dataset_root, entry, input_w, input_h)
+            future.add_done_callback(entry_done)      # FIXME: doesn't work if chained directly to submit(). bug in futures? reproduce and submit report.
+    nonlocals['entries_done_pbar'].close()
+    return nonlocals['metadata']
+
+
+def get_entry_metadata(dataset_root, entry, input_w, input_h):
+    """
+    NOTE: this must be a global function (so that it can be used by ProcessPoolExecutor)
+    """
+    id_cmd = ['gm', 'identify', '-format', '%G', os.path.join(dataset_root, 'training', 'image_2', entry + '.*')]
+    try:
+        out = subprocess.check_output(id_cmd)
+    except subprocess.CalledProcessError:
+        print 'Unable to process entry', entry, '(ignoring)'
+        return None
+
+    # print '>>> ', entry, ' out: ', out
+    img_w, img_h = [int(x) for x in out.split('x')]
+    scaleX = float(input_w) / img_w
+    scaleY = float(input_h) / img_h
+
+    bbox_sizes = []
+    with open(os.path.join(dataset_root, 'training', 'label_2', entry + '.txt')) as f:
+        for line in f.read().splitlines():
+            if line:
+                # n02676566 0.0 0 0 21 1 376 547 -1 -1 -1 -1 -1 -1 -1
+                xmin, ymin, xmax, ymax = [int(x) for x in line.split()[4:8]]
+                w = xmax - xmin
+                h = ymax - ymin
+                bbox_sizes.append((w * scaleX, h * scaleY))
+    return {
+        'size': (img_w, img_h),
+        'bbox_sizes': bbox_sizes
+    }
+
+
+def print_anchors(k, metadata):
+    bbox_sizes = np.array(flatten([m['bbox_sizes'] for m in metadata.values()]))
+    plt.scatter(bbox_sizes[:, 0], bbox_sizes[:, 1])
+    plt.xlabel('width')
+    plt.ylabel('height')
+
+    kmeans = KMeans(n_clusters=k, random_state=0).fit(bbox_sizes)
+    centroids = kmeans.cluster_centers_
+    print_nicely(centroids)
+
+    plt.gca().set_aspect('equal', adjustable='box')
+
+    plt.plot(centroids[:, 0], centroids[:, 1], 'x', color='red')
+
+    plt.show()
+
+
+def print_nicely(centroids):
+    out = '\n\n# Replace the Python list in anchor_shapes (in set_anchors() under src/config/kitti_<your_model>_config.py) with this one:\n'
+    out += '['
+    centroids_list = centroids.tolist()
+    for idx, entry in enumerate(centroids_list):
+        out += '[%.2f, %.2f]' % (entry[0], entry[1])
+        comma, space, newline = '', '', ''
+        if idx != len(centroids_list) - 1:
+            comma = ','
+            space = ' '
+        if idx % 3 == 2:
+            newline = '\n'
+            space = ''
+        out += comma + space + newline
+    out += ']'
+    print out
+
+
+
+if __name__=='__main__':
+    main()


### PR DESCRIPTION
Hi @BichenWuUCB,
Many thanks for publishing the sources for your model.

I'm working on fitting it to my own dataset (more smartphone-camera shaped), and one of the things I needed to do was to adapt the shapes of the anchors.

Here I'm sharing the script I used for finding the optimal anchor sizes.

Note however that for the KITTI dataset I don't get at all the same results as the ones in the repository:
In `config/kitti_res50_config.py`:
```
         [[  94.,  49.], [ 225., 161.], [ 170.,  91.],
           [ 390., 181.], [  41.,  32.], [ 128.,  64.],
           [ 298., 164.], [ 232.,  99.], [  65.,  42.]])]
```
In `config/kitti_squeezeDet_config.py`:
```
          [[  36.,  37.], [ 366., 174.], [ 115.,  59.],
           [ 162.,  87.], [  38.,  90.], [ 258., 173.],
           [ 224., 108.], [  78., 170.], [  72.,  43.]])]
```

What I get instead is:
```Shell
$ python scripts/kmeans_anchors.py --geometry 1248x384 --kmeans-max-iter 1000000
...
[[70.45, 41.96], [390.36, 165.54], [125.10, 66.58],
[98.62, 186.29], [29.57, 26.18], [43.72, 94.05],
[356.65, 339.55], [269.63, 170.46], [198.84, 101.97]]
```
<img width="752" alt="screen shot 2017-06-16 at 17 52 44" src="https://user-images.githubusercontent.com/5825990/27234363-0a3707a0-52bd-11e7-883a-a654c844513a.png">

Note for example that the "wide and short" sizes don't get an anchor, but maybe it's fair... Have I missed something? Could you have a look, and consider merging it if the implementation is correct? (I'm new to the field of machine learning, so not 100% confident)

Cheers,
Mihai