### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ joblib==0.10.3
 numpy==1.12.0
 opencv-python==3.2.0.6
 Pillow==4.0.0
-tensorflow-gpu==1.0.0
+tensorflow-gpu>=1.0.0


### PR DESCRIPTION
If user has already tensorflow-gpu1.3.0 and executes `pip install -r requirements.txt` then the older version is installed and this causes a cuDNN error: undefined symbol: cudnnCreate